### PR TITLE
Fixed g++ compile error and warning

### DIFF
--- a/gtkglswitch.cpp
+++ b/gtkglswitch.cpp
@@ -124,20 +124,21 @@ int main(int argc, char *argv[])
 {
   char *opt_default = NULL;
   GError *error = NULL;
-  if (!gtk_init_with_args
-       (&argc, &argv, NULL,
-        (GOptionEntry[]){
+  static GOptionEntry entries [] = {
          {"default", 'D', 0, G_OPTION_ARG_STRING, &opt_default, "assume default answer", ""},
-          0},
-        NULL, &error))
+	 {NULL} 
+  };
+
+  if (!gtk_init_with_args(&argc, &argv, NULL, entries, NULL, &error))
     die("GTK initialization failed: %s", error->message);
-  if (opt_default)
+  if (opt_default) {
     if (!strcmp(opt_default, "yes"))
       switch_default = SWITCH_DEFAULT_YES;
     else if (!strcmp(opt_default, "no"))
       switch_default = SWITCH_DEFAULT_NO;
     else
       die("invalid default answer: %s", opt_default);
+  }
 
   struct sockaddr_un addr;
   addr.sun_family = AF_UNIX;


### PR DESCRIPTION
```
g++ -Wall -O2 -march=native -g -DLIBPATH='"/usr"' -DALTPATH='"/primus"' -DLIB64PATH='"/lib"' \ 
    -DLIB32PATH='"/lib32"' `pkg-config --cflags --libs gtk+-2.0` -o gtkglswitch gtkglswitch.cpp
gtkglswitch.cpp: In function 'int main(int, char**)':
gtkglswitch.cpp:132:21: error: taking address of temporary array
         NULL, &error))
                     ^
gtkglswitch.cpp:134:6: warning: suggest explicit braces to avoid ambiguous 'else' [-Wparentheses]
   if (opt_default)
```
